### PR TITLE
Fix subqueries not resolving columns with alias

### DIFF
--- a/server/src/ZetaSqlParser.ts
+++ b/server/src/ZetaSqlParser.ts
@@ -8,6 +8,7 @@ import { ParseResponse__Output } from '@fivetrandevelopers/zetasql/lib/types/zet
 import { ZetaSqlApi } from './ZetaSqlApi';
 import { arraysAreEqual } from './utils/Utils';
 import { traverse } from './utils/ZetaSqlUtils';
+import { ASTAliasProto__Output } from '@fivetrandevelopers/zetasql/lib/types/zetasql/ASTAliasProto';
 
 interface KnownSelect {
   parseLocationRange: ParseLocationRangeProto__Output;
@@ -17,6 +18,7 @@ interface KnownSelect {
 interface KnownColumn {
   namePath: string[];
   parseLocationRange: ParseLocationRangeProto__Output;
+  alias?: string;
 }
 
 export interface ParseResult {
@@ -65,7 +67,7 @@ export class ZetaSqlParser {
                   parentSelect.push(select);
                   result.selects.push(select);
 
-                  typedNode.selectList?.columns.forEach(c => select.columns.push(...this.getColumns(c.expression)));
+                  typedNode.selectList?.columns.forEach(c => select.columns.push(...this.getColumns(c.expression, c.alias ?? undefined)));
                 }
               },
               actionAfter: () => parentSelect.pop(),
@@ -95,7 +97,7 @@ export class ZetaSqlParser {
     return result;
   }
 
-  getColumns(node: AnyASTExpressionProto__Output | null): KnownColumn[] {
+  getColumns(node: AnyASTExpressionProto__Output | null, alias?: ASTAliasProto__Output): KnownColumn[] {
     if (!node) {
       return [];
     }
@@ -109,6 +111,7 @@ export class ZetaSqlParser {
           columns.push({
             namePath: pathExpression.names.map(n => n.idString),
             parseLocationRange,
+            alias: alias ? alias.identifier?.idString : undefined,
           });
         }
         break;

--- a/server/src/definition/SqlDefinitionProvider.ts
+++ b/server/src/definition/SqlDefinitionProvider.ts
@@ -101,7 +101,7 @@ export class SqlDefinitionProvider {
 
                 let targetColumnRawRange = targetRange;
                 if (targetSelect) {
-                  const targetColumn = targetSelect.columns.find(c => c.namePath.at(-1) === clickedColumn.name);
+                  const targetColumn = targetSelect.columns.find(c => c.alias === clickedColumn.name || c.namePath.at(-1) === clickedColumn.name);
                   if (targetColumn) {
                     targetColumnRawRange = Range.create(
                       positionConverter.convertPositionBackward(targetColumn.compiledRange.start),

--- a/server/src/document/DbtTextDocument.ts
+++ b/server/src/document/DbtTextDocument.ts
@@ -47,6 +47,7 @@ export interface QueryParseInformation {
       namePath: string[];
       rawRange: Range;
       compiledRange: Range;
+      alias?: string;
     }[];
     tableAliases: Map<string, string>;
     parseLocationRange: Location;


### PR DESCRIPTION
The issue is that if a column has an alias in a CTE, go-to-definition won't resolve the alias. Example code:

```sql
with some_cte as ( select suppliers.supplier_id as some_alias -- Technically resolves to namePath [supplier, supplier_id]
    from {{ prod_ref('ODL_base__suppliers') }} as suppliers
)

select some_alias -- Previousy looked for only namePath [some_alias] which doesn't match [supplier, supplier_id]
from some_cte
```

Changed this process to also store the alias of a column and compare against that.