### PR TITLE
Implement go to column definition for columns in not-currently-open files

### DIFF
--- a/server/src/definition/DefinitionProvider.ts
+++ b/server/src/definition/DefinitionProvider.ts
@@ -7,6 +7,7 @@ import { QueryParseInformation } from '../document/DbtTextDocument';
 import { positionInRange } from '../utils/Utils';
 import { DbtDefinitionProvider } from './DbtDefinitionProvider';
 import { SqlDefinitionProvider } from './SqlDefinitionProvider';
+import { LspServer } from '../lsp_server/LspServer';
 
 export class DefinitionProvider {
   dbtDefinitionProvider: DbtDefinitionProvider;
@@ -15,9 +16,10 @@ export class DefinitionProvider {
   constructor(
     dbtRepository: DbtRepository,
     private jinjaParser: JinjaParser,
+    getServer: () => LspServer | undefined,
   ) {
     this.dbtDefinitionProvider = new DbtDefinitionProvider(dbtRepository);
-    this.sqlDefinitionProvider = new SqlDefinitionProvider(dbtRepository);
+    this.sqlDefinitionProvider = new SqlDefinitionProvider(dbtRepository, getServer);
   }
 
   async onDefinition(

--- a/server/src/document/DbtTextDocument.ts
+++ b/server/src/document/DbtTextDocument.ts
@@ -41,13 +41,15 @@ import { areRangesEqual, debounce, getIdentifierRangeAtPosition, getModelPathOrF
 import { DbtDocumentKind } from './DbtDocumentKind';
 import { RefReplacement } from 'dbt-language-server-common';
 
+export interface QueryParseInformationSelectColumn {
+  namePath: string[];
+  rawRange: Range;
+  compiledRange: Range;
+}
+
 export interface QueryParseInformation {
   selects: {
-    columns: {
-      namePath: string[];
-      rawRange: Range;
-      compiledRange: Range;
-    }[];
+    columns: QueryParseInformationSelectColumn[];
     tableAliases: Map<string, string>;
     parseLocationRange: Location;
   }[];

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -96,7 +96,8 @@ function createLspServerForProject(
   const dbtDocumentKindResolver = new DbtDocumentKindResolver(dbtRepository);
   const diagnosticGenerator = new DiagnosticGenerator(dbtRepository);
   const jinjaParser = new JinjaParser();
-  const definitionProvider = new DefinitionProvider(dbtRepository, jinjaParser);
+  let server: LspServer | undefined = undefined;
+  const definitionProvider = new DefinitionProvider(dbtRepository, jinjaParser, () => server);
   const signatureHelpProvider = new SignatureHelpProvider();
   const hoverProvider = new HoverProvider();
   const openedDocuments = new Map<string, DbtTextDocument>();
@@ -113,7 +114,7 @@ function createLspServerForProject(
     macroCompilationServer,
   );
 
-  return new LspServer(
+  server = new LspServer(
     connection,
     notificationSender,
     featureFinder,
@@ -135,6 +136,7 @@ function createLspServerForProject(
     projectChangeListener,
     customInitParams.enableSnowflakeSyntaxCheck,
   );
+  return server;
 }
 
 connection.listen();

--- a/server/src/test/document/DbtTextDocument.spec.ts
+++ b/server/src/test/document/DbtTextDocument.spec.ts
@@ -66,7 +66,7 @@ describe('DbtTextDocument', () => {
       new DiagnosticGenerator(dbtRepository),
       new SignatureHelpProvider(),
       new HoverProvider(),
-      new DefinitionProvider(dbtRepository, instance(mockJinjaParser)),
+      new DefinitionProvider(dbtRepository, instance(mockJinjaParser), () => undefined),
       instance(mockProjectChangeListener),
     );
   });


### PR DESCRIPTION
Go to column definition does not work if the referenced column falls outside of the current file. This PR fixes that by just-in-time getting the location of the referenced column and jumping to it.